### PR TITLE
Re-enable history for Sensibo, expose hvac_action

### DIFF
--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -16,6 +16,11 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_FAN_ONLY,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
+    CURRENT_HVAC_OFF,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_DRY,
+    CURRENT_HVAC_FAN,
     SUPPORT_FAN_MODE,
     SUPPORT_SWING_MODE,
     SUPPORT_TARGET_TEMPERATURE,
@@ -226,6 +231,23 @@ class SensiboClimate(ClimateDevice):
         if not self._ac_states["on"]:
             return HVAC_MODE_OFF
         return SENSIBO_TO_HA.get(self._ac_states["mode"])
+
+    @property
+    def hvac_action(self):
+        """Return current action ie. heating, cooling etc."""
+        if self.hvac_mode == HVAC_MODE_HEAT:
+            return CURRENT_HVAC_HEAT
+        if self.hvac_mode == HVAC_MODE_COOL:
+            return CURRENT_HVAC_COOL
+        if self.hvac_mode == HVAC_MODE_DRY:
+            return CURRENT_HVAC_DRY
+        if self.hvac_mode == HVAC_MODE_FAN_ONLY:
+            return CURRENT_HVAC_FAN
+        if self.hvac_mode == HVAC_MODE_HEAT_COOL:
+            # no way of knowing what we're actually doing, return something to show 'on'
+            return CURRENT_HVAC_HEAT
+
+        return CURRENT_HVAC_OFF
 
     @property
     def current_humidity(self):


### PR DESCRIPTION
## Breaking Change:


## Description:
hvac_action now a required property to display history in climate UI.  This PR adds the property for Sensibo.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: sensibo
    api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
